### PR TITLE
 Add link type and support for clipboard-only links

### DIFF
--- a/.changeset/warm-planets-try.md
+++ b/.changeset/warm-planets-try.md
@@ -1,0 +1,5 @@
+---
+"storybook-addon-source-link": minor
+---
+
+Add link type and support for clipboard-only links

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ If `undefined` is returned, the link will not be added.
   - `label`: The label of the link.
   - `href`: The URL of the link.
   - `icon`: (Optional) The icon name in [@storybook/icons](https://main--64b56e737c0aeefed9d5e675.chromatic.com/?path=/docs/introduction--docs)
+  - `type`: (Optional) The type of the link.
+    - `"link"`: The link will be opened in the same tab.
+    - `"linkBlank"`: (default) The link will be opened in a new tab. Added target="\_blank" to the link.
+    - `"copy"`: The link will be copied to the clipboard.
   - `order`: (Optional) When order is specified, it will be sorted in ascending order. The default value is `0`.
 
 ### Preset settings provided by the addon

--- a/packages/addon-source-link/src/types.ts
+++ b/packages/addon-source-link/src/types.ts
@@ -69,5 +69,16 @@ export type LinkEntry =
 			 * When order is specified, it will be sorted in ascending order. The default value is `0`.
 			 */
 			order?: number | undefined;
+
+			/**
+			 * The type of the link.
+			 *
+			 * - `"link"`: The link will be opened in the same tab.
+			 * - `"linkBlank"`: The link will be opened in a new tab. Added target="_blank" to the link.
+			 * - `"copy"`: The link will be copied to the clipboard.
+			 *
+			 * @default "linkBlank"
+			 */
+			type?: "link" | "linkBlank" | "copy" | undefined;
 	  }
 	| undefined;

--- a/packages/addon-source-link/src/types.ts
+++ b/packages/addon-source-link/src/types.ts
@@ -53,9 +53,21 @@ export type Resolvable<T> = ((context: ResolveContext) => T) | T;
 
 export type LinkEntry =
 	| {
+			/**
+			 * The label of the link.
+			 */
 			label: string;
+			/**
+			 * The URL of the link.
+			 */
 			href: string;
+			/**
+			 * The icon name in [@storybook/icons](https://main--64b56e737c0aeefed9d5e675.chromatic.com/?path=/docs/introduction--docs)
+			 */
 			icon?: IconName | undefined;
+			/**
+			 * When order is specified, it will be sorted in ascending order. The default value is `0`.
+			 */
 			order?: number | undefined;
 	  }
 	| undefined;

--- a/packages/demo/.storybook/preview.tsx
+++ b/packages/demo/.storybook/preview.tsx
@@ -38,6 +38,16 @@ const preview: Preview = {
 						icon: "GithubIcon",
 					};
 				},
+				"story-github-copy": ({ importPath, rootPath }) => {
+					if (!rootPath) return undefined;
+					const href = `https://github.com/elecdeer/storybook-addon-source-link/blob/-/packages/demo${importPath.replace(/^\./, "")}`;
+					return {
+						label: importPath,
+						href,
+						type: "copy",
+						icon: "GithubIcon",
+					};
+				},
 			},
 		} satisfies SourceLinkParameter,
 	},


### PR DESCRIPTION
Add link type parameter.
- `"link"`: The link will be opened in the same tab.
- `"linkBlank"`: (default) The link will be opened in a new tab. Added target="_blank" to the link. 
- `"copy"`: The link will be copied to the clipboard.