### PR TITLE
chore: remove unused 'vite' dependency from pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,6 @@ catalog:
   storybook: ^9.1.1
   tsup: ^8.5.0
   typescript: ^5.9.2
-  vite: ^5.4.19
   zx: ^8.8.0
 
 catalogMode: prefer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "vite" dependency from the catalog section of the workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->