### PR TITLE
ci: add e2e testing workflow with Node.js 22

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Run E2E tests (dev)
         run: pnpm --filter e2e run test:dev
 
+      - name: Build Storybook for static testing
+        run: pnpm --filter e2e run build-storybook
+
       - name: Run E2E tests (build)
         run: pnpm --filter e2e run test:build
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,10 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-    branches:
-      - main
-      - ci/e2e
   pull_request:
 
 concurrency: 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,9 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.54.0-noble
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,9 +30,6 @@ jobs:
 
       - name: Build packages
         run: pnpm run -r build
-
-      - name: Install Playwright Browsers
-        run: pnpm --filter e2e exec playwright install --with-deps
 
       - name: Run E2E tests (dev)
         run: pnpm --filter e2e run test:dev

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,50 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+      - ci/e2e
+  pull_request:
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Enable corepack
+        run: corepack enable pnpm
+  
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run -r build
+
+      - name: Install Playwright Browsers
+        run: pnpm --filter e2e exec playwright install --with-deps
+
+      - name: Run E2E tests (dev)
+        run: pnpm --filter e2e run test:dev
+
+      - name: Run E2E tests (build)
+        run: pnpm --filter e2e run test:build
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: packages/e2e/playwright-report/
+          retention-days: 30

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Enable corepack
         run: corepack enable pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       
       - name: Enable corepack
         run: corepack enable pnpm

--- a/packages/e2e/stories/Header.stories.ts
+++ b/packages/e2e/stories/Header.stories.ts
@@ -5,6 +5,7 @@ import type {
 	ResolveContext,
 	SourceLinkParameter,
 } from "storybook-addon-source-link";
+import { joinPath } from "storybook-addon-source-link";
 
 import { Header } from "./Header";
 
@@ -92,14 +93,14 @@ export const WithFunctionLinks: Story = {
 					if (isStaticBuild) {
 						return {
 							label: "GitHub (Static Build)",
-							href: `https://github.com/elecdeer/storybook-addon-source-link/blob/main/packages/e2e${importPath}`,
+							href: `https://github.com/elecdeer/storybook-addon-source-link/blob/main/${joinPath("packages/e2e", importPath)}`,
 							icon: "GithubIcon",
 							order: 1,
 						};
 					}
 					return {
 						label: "GitHub (Dev Mode)",
-						href: `https://github.com/elecdeer/storybook-addon-source-link/blob/main/packages/e2e${importPath}`,
+						href: `https://github.com/elecdeer/storybook-addon-source-link/blob/main/${joinPath("packages/e2e", importPath)}`,
 						icon: "GithubIcon",
 						order: 1,
 					};


### PR DESCRIPTION
Add automated e2e testing for storybook-addon-source-link using Playwright. Supports both development server and static build testing with artifact upload on failure.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a CI workflow to run end-to-end tests on pull requests only; runs tests in dev and build modes inside a Playwright-enabled container and uploads failure reports (retained 30 days).

- **Chores**
  - Enabled workflow concurrency to cancel redundant in-progress runs, improving pipeline efficiency.

- **Documentation**
  - Updated Storybook source links for end-to-end stories so GitHub source URLs are constructed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->