### PR TITLE
Feat/renovate changeset automation

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,10 +15,10 @@ jobs:
       options: --user 1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
 
@@ -41,7 +41,7 @@ jobs:
         run: pnpm --filter e2e run test:build
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: playwright-report

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
       
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm run release

--- a/.github/workflows/renovate-changesets.yml
+++ b/.github/workflows/renovate-changesets.yml
@@ -1,0 +1,127 @@
+name: Add Changeset to Renovate PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  add-changeset:
+    if: ${{ startsWith(github.head_ref, 'renovate/') }}
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check and create changeset
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { execSync } = require('child_process');
+            
+            const CHANGESET_DIR = '.changeset';
+            const PACKAGE_NAME = 'storybook-addon-source-link';
+            
+            function execCommand(command) {
+              return execSync(command, { encoding: 'utf8' }).trim();
+            }
+            
+            function getChangedChangesetFiles() {
+              const changedFiles = execCommand('git diff --name-only HEAD~1 HEAD').split('\n');
+              return changedFiles.filter(file => 
+                file.startsWith('.changeset/') && 
+                file.endsWith('.md') && 
+                !file.includes('README.md')
+              );
+            }
+            
+            function isChangesetCreatedByBot(changesetFiles) {
+              if (changesetFiles.length === 0) return false;
+              
+              try {
+                const changesetCommit = execCommand(
+                  "git log --oneline --follow --diff-filter=A HEAD~1..HEAD -- '.changeset/*.md'"
+                ).split('\n')[0];
+                
+                if (!changesetCommit) return false;
+                
+                const commitHash = changesetCommit.split(' ')[0];
+                const commitAuthor = execCommand(`git log --format="%an" -n 1 ${commitHash}`);
+                
+                const isBotCreated = commitAuthor === 'GitHub Action' || commitAuthor.includes('[bot]');
+                console.log(`Changeset author: ${commitAuthor}, bot created: ${isBotCreated}`);
+                
+                return isBotCreated;
+              } catch (error) {
+                console.log('Error checking changeset author:', error.message);
+                return false;
+              }
+            }
+            
+            function createChangesetContent(commitMessage) {
+              return [
+                '---',
+                `"${PACKAGE_NAME}": patch`,
+                '---',
+                '',
+                commitMessage,
+                ''
+              ].join('\n');
+            }
+            
+            function setupGitConfig() {
+              execCommand('git config --local user.email "action@github.com"');
+              execCommand('git config --local user.name "GitHub Action"');
+            }
+            
+            function commitAndPush() {
+              execCommand('git add .changeset/');
+              
+              try {
+                execCommand('git diff --staged --quiet');
+                console.log('No changeset to commit');
+              } catch (error) {
+                execCommand('git commit -m "chore: add changeset for renovate PR"');
+                execCommand(`git push origin ${context.payload.pull_request.head.ref}`);
+                console.log('Changeset committed and pushed');
+              }
+            }
+            
+            // Main logic
+            const stagedChangesets = getChangedChangesetFiles();
+            console.log(`Found ${stagedChangesets.length} staged changeset files`);
+            
+            const botCreated = isChangesetCreatedByBot(stagedChangesets);
+            
+            // Determine action based on changeset state
+            if (stagedChangesets.length > 0 && !botCreated) {
+              console.log('Human-created changeset exists, skipping');
+              return;
+            }
+            
+            const commitMessage = execCommand('git log --format="%s" -n 1');
+            console.log(`Commit message: ${commitMessage}`);
+            
+            const changesetContent = createChangesetContent(commitMessage);
+            
+            let changesetPath;
+            if (botCreated && stagedChangesets.length > 0) {
+              changesetPath = stagedChangesets[0];
+              console.log(`Overwriting bot-created changeset: ${changesetPath}`);
+            } else {
+              const timestamp = Date.now();
+              changesetPath = path.join(CHANGESET_DIR, `renovate-${timestamp}.md`);
+              console.log(`Creating new changeset: ${changesetPath}`);
+            }
+            
+            fs.writeFileSync(changesetPath, changesetContent);
+            setupGitConfig();
+            commitAndPush();

--- a/.github/workflows/renovate-changesets.yml
+++ b/.github/workflows/renovate-changesets.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Check and create changeset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/renovate-changesets.yml
+++ b/.github/workflows/renovate-changesets.yml
@@ -36,7 +36,18 @@ jobs:
             }
             
             function getChangedChangesetFiles() {
-              const changedFiles = execCommand('git diff --name-only HEAD~1 HEAD').split('\n');
+              // Get PR base branch and ensure it's fetched
+              const baseSha = context.payload.pull_request.base.sha;
+              const baseBranch = context.payload.pull_request.base.ref;
+              
+              try {
+                execCommand(`git fetch origin ${baseBranch}`);
+              } catch (error) {
+                console.log(`Warning: Could not fetch base branch ${baseBranch}:`, error.message);
+              }
+              
+              // Compare entire PR (base to HEAD) instead of just last commit
+              const changedFiles = execCommand(`git diff --name-only ${baseSha}..HEAD`).split('\n');
               return changedFiles.filter(file => 
                 file.startsWith('.changeset/') && 
                 file.endsWith('.md') && 
@@ -48,19 +59,26 @@ jobs:
               if (changesetFiles.length === 0) return false;
               
               try {
-                const changesetCommit = execCommand(
-                  "git log --oneline --follow --diff-filter=A HEAD~1..HEAD -- '.changeset/*.md'"
-                ).split('\n')[0];
+                // Check each changeset file to see if any were created by a bot
+                for (const changesetFile of changesetFiles) {
+                  console.log(`Checking author of changeset file: ${changesetFile}`);
+                  
+                  // Get the author who added this specific file
+                  const commitAuthor = execCommand(
+                    `git log -n 1 --format="%an" --diff-filter=A -- ${changesetFile}`
+                  );
+                  
+                  console.log(`Author of ${changesetFile}: ${commitAuthor}`);
+                  
+                  const isBotCreated = commitAuthor === 'GitHub Action' || commitAuthor.includes('[bot]');
+                  if (isBotCreated) {
+                    console.log(`Found bot-created changeset: ${changesetFile}`);
+                    return true;
+                  }
+                }
                 
-                if (!changesetCommit) return false;
-                
-                const commitHash = changesetCommit.split(' ')[0];
-                const commitAuthor = execCommand(`git log --format="%an" -n 1 ${commitHash}`);
-                
-                const isBotCreated = commitAuthor === 'GitHub Action' || commitAuthor.includes('[bot]');
-                console.log(`Changeset author: ${commitAuthor}, bot created: ${isBotCreated}`);
-                
-                return isBotCreated;
+                console.log('No bot-created changesets found');
+                return false;
               } catch (error) {
                 console.log('Error checking changeset author:', error.message);
                 return false;

--- a/.github/workflows/renovate-changesets.yml
+++ b/.github/workflows/renovate-changesets.yml
@@ -15,12 +15,12 @@ jobs:
     
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check and create changeset
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Pinned GitHub Actions used in CI and release workflows to specific commit references for more deterministic runs.
  - Added a workflow to automate changeset management on Renovate pull requests, creating or updating patch changesets based on PR activity and commit messages.
  - Minor formatting cleanup: ensured trailing newline in a workflow file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->