### PR TITLE
chore: fix package metadata links

### DIFF
--- a/.changeset/fix-package-metadata-links.md
+++ b/.changeset/fix-package-metadata-links.md
@@ -1,0 +1,5 @@
+---
+"storybook-addon-source-link": patch
+---
+
+Fixed package metadata links.

--- a/packages/addon-source-link/package.json
+++ b/packages/addon-source-link/package.json
@@ -11,8 +11,12 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/elecdeer/storybook-addon-source-link/tree/main.git"
+		"url": "git+https://github.com/elecdeer/storybook-addon-source-link.git"
 	},
+	"bugs": {
+		"url": "https://github.com/elecdeer/storybook-addon-source-link/issues"
+	},
+	"homepage": "https://github.com/elecdeer/storybook-addon-source-link#readme",
 	"type": "module",
 	"license": "MIT",
 	"author": "elecdeer",


### PR DESCRIPTION
## Summary
- fix the package repository URL so it points to the git repository root
- add explicit bugs and homepage metadata
- leave runtime code, dependencies, entry points, and package files unchanged

## Validation
- node package metadata assertion
- npm pack --dry-run --ignore-scripts --json --cache /private/tmp/codex-npm-cache-storybook-source-link
- git diff --check