### PR TITLE
fix: remove stale manager-helpers export

### DIFF
--- a/.changeset/calm-tools-listen.md
+++ b/.changeset/calm-tools-listen.md
@@ -1,0 +1,5 @@
+---
+"storybook-addon-source-link": patch
+---
+
+Remove the stale `./manager-helpers` export, which pointed to a file that is not built or published.

--- a/packages/addon-source-link/package.json
+++ b/packages/addon-source-link/package.json
@@ -24,7 +24,6 @@
 		"./preset": "./dist/preset.js",
 		"./preview": "./dist/preview.js",
 		"./manager": "./dist/manager.js",
-		"./manager-helpers": "./dist/manager-helpers.js",
 		"./package.json": "./package.json"
 	},
 	"files": [


### PR DESCRIPTION
## Summary

- remove the stale `./manager-helpers` package export
- add a patch changeset for the corrected published surface

`storybook-addon-source-link@2.0.1` currently maps `./manager-helpers` to `./dist/manager-helpers.js`, but that file is not present in the npm tarball. The repository also has no corresponding source or bundler entry, so consumers receive `ERR_MODULE_NOT_FOUND` when resolving the advertised subpath.

## Validation

- reproduced the missing target with `npm view storybook-addon-source-link@2.0.1 exports --json`
- confirmed the published tarball lacks `dist/manager-helpers.js` with `npm pack storybook-addon-source-link@2.0.1 --dry-run --ignore-scripts --json`
- ran a manifest-to-tarball assertion: the published manifest has one missing target, while the patched manifest has zero
- `corepack pnpm -F storybook-addon-source-link run type-check`
- `git diff --check`